### PR TITLE
Fixing bi-directional locking for parent-child segments and modifying…

### DIFF
--- a/strategy/sampling/centralized.go
+++ b/strategy/sampling/centralized.go
@@ -444,11 +444,12 @@ func (ss *CentralizedStrategy) refreshTargets() (err error) {
 // samplingStatistics takes a snapshot of sampling statistics from all rules, resetting
 // statistics counters in the process.
 func (ss *CentralizedStrategy) snapshots() []*xraySvc.SamplingStatisticsDocument {
-	statistics := make([]*xraySvc.SamplingStatisticsDocument, 0, len(ss.manifest.Rules)+1)
 	now := ss.clock.Now().Unix()
 
 	ss.manifest.mu.RLock()
 	defer ss.manifest.mu.RUnlock()
+
+	statistics := make([]*xraySvc.SamplingStatisticsDocument, 0, len(ss.manifest.Rules)+1)
 
 	// Generate sampling statistics for user-defined rules
 	for _, r := range ss.manifest.Rules {

--- a/strategy/sampling/sampling_rule.go
+++ b/strategy/sampling/sampling_rule.go
@@ -92,8 +92,8 @@ type CentralizedRule struct {
 
 // stale returns true if the quota is due for a refresh. False otherwise.
 func (r *CentralizedRule) stale(now int64) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 
 	return r.requests != 0 && now >= r.reservoir.refreshedAt+r.reservoir.interval
 }

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -96,8 +96,13 @@ var xRayAfterSendHandler = request.NamedHandler{
 		if curseg != nil && curseg.Name == "attempt" {
 			// An error could have prevented the connect subsegment from closing,
 			// so clean it up here.
-			for _, subsegment := range curseg.rawSubsegments {
-				if subsegment.Name == "connect" && subsegment.safeInProgress() {
+			curseg.RLock()
+			temp := make([]*Segment, len(curseg.rawSubsegments))
+			copy(temp, curseg.rawSubsegments)
+			curseg.RUnlock()
+
+			for _, subsegment := range temp {
+				if subsegment.getName() == "connect" && subsegment.safeInProgress() {
 					subsegment.Close(nil)
 					return
 				}

--- a/xray/segment_model.go
+++ b/xray/segment_model.go
@@ -19,10 +19,10 @@ import (
 
 // Segment provides the resource's name, details about the request, and details about the work done.
 type Segment struct {
-	sync.Mutex
+	sync.RWMutex
 	parent           *Segment
 	openSegments     int
-	totalSubSegments int
+	totalSubSegments uint32
 	Sampled          bool           `json:"-"`
 	RequestWasTraced bool           `json:"-"` // Used by xray.RequestWasTraced
 	ContextDone      bool           `json:"-"`


### PR DESCRIPTION
… lock on Segment struct to RWMutex (#140)

* Fixing bi-directional locking for parent-child segments

Bi-directional locking on parent/child (Sub)Segment leads to deadlocks
and data race conditions. This commit fixes this issue by making locking
uni-directional

* updating the unit test

* Changing lock on Segment struct to RWMutex

Changing lock on Segment struct to granular locking. Modified locks to read lock wherever there is read only access on Segment fields.

* thread safe attempt subsegment name access and updating indentation

* Making deep copy for attempt subsegments and refactoring code for flush()

* fixing totalSegments count on ParentSegment

This commit, correctly counts totalSegments count registered on
ParentSegment. This count is important to decide Subsegment streaming in
the tree. Previous to this commit, the counting wasn't accurate leading
to incorrect streaming by the SDK.

* Indenting code

* removing unnecessary seg type check while logging

* adding indentation

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
